### PR TITLE
Fix content type for jsn requests

### DIFF
--- a/production/utils/Event.js
+++ b/production/utils/Event.js
@@ -66,8 +66,8 @@ class Event {
         } catch (e) {//
         }
       }
-    } else {} // reject(`not bind ${eventType} event`);
-      // });
+    } else {// reject(`not bind ${eventType} event`);
+    } // });
 
   }
 

--- a/production/utils/request.js
+++ b/production/utils/request.js
@@ -74,6 +74,7 @@ let requestWrap = opt => {
       });
     } else if (typeof body === 'object') {
       newBody = JSON.stringify(body);
+      headers['Content-Type'] = 'application/json';
     }
 
     let dataOption = {

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -51,6 +51,7 @@ let requestWrap = opt => {
     }
     else if(typeof body==='object'){
       newBody=JSON.stringify(body);
+      headers['Content-Type']='application/json';
     }
     
     let dataOption={


### PR DESCRIPTION
During message sent, the api response is 

```
{
  status: 500,
  message: {
    code: 500,
    message: "Content type 'text/plain;charset=UTF-8' not supported",
    tid: 'c7b2e249eae16f19',
    sid: 'c7b2e249eae16f19'
  }
}
```

with this fix, the correct content type is passed in headers